### PR TITLE
Improvements to the makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ main ?= .
 output ?= event-generator
 
 .PHONY: build
-build: clean events/k8saudit/yaml ${output}
+build: clean events/k8saudit/yaml/bundle.go ${output}
 
 .PHONY: ${output}
 ${output}:
@@ -17,13 +17,12 @@ ${output}:
 .PHONY: clean
 clean:
 	$(RM) -R ${output}
+	$(RM) -f events/k8saudit/yaml/bundle.go
 
 .PHONY: test
 test:
 	$(GO) vet ./...
 	$(GO) test ${TEST_FLAGS} ./...
 
-
-.PHONY: events/k8saudit/yaml
-events/k8saudit/yaml:
-	go run ./tools/file-bundler/ events/k8saudit/yaml
+events/k8saudit/yaml/bundle.go: events/k8saudit/yaml events/k8saudit/yaml/*.yaml
+	$(GO) run ./tools/file-bundler/ $<


### PR DESCRIPTION
Just nitpicking on the makefile, but with changes I think are necessary. :)

Regenerate YAML Go bundle only if necessary.
Clean it when `make clean`.
Depend on that `bundle.go` file when building.

cc @leogr 

Signed-off-by: Leonardo Di Donato <leodidonato@gmail.com>